### PR TITLE
Fix text inputs on iOS

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -43,3 +43,9 @@
 :focus {
     outline: none !important;
 }
+
+/* allow text selection on input elements */
+input {
+  user-select: text;
+  -webkit-user-select: text;
+}


### PR DESCRIPTION
When the `user-select` CSS property is set to `none`, the text input fields become unusable on iOS. Setting the property to `text` fixes this.

Example from `/login`:

https://user-images.githubusercontent.com/45981228/223291293-7c986f67-ca5c-411c-afa4-fd64a5053ef2.mov

<br>
fixes #5 